### PR TITLE
Fix symptom upgrade

### DIFF
--- a/food_diary/lib/data/datasources/symptom_local_datasource.dart
+++ b/food_diary/lib/data/datasources/symptom_local_datasource.dart
@@ -49,6 +49,11 @@ class SymptomLocalDataSourceImpl implements SymptomLocalDataSource {
 
   Future<void> _onUpgrade(Database db, int oldVersion, int newVersion) async {
     if (oldVersion < 2) {
+      // Recreate the table for the new schema. The previous implementation
+      // attempted to call `_onCreate` directly which would fail if the table
+      // already existed. Dropping the old table first avoids the "table already
+      // exists" error when migrating from older versions.
+      await db.execute('DROP TABLE IF EXISTS $_tableName');
       await _onCreate(db, newVersion);
     }
   }


### PR DESCRIPTION
## Summary
- fix dropping old table during symptom database upgrade

## Testing
- `dart test/test/symptom_local_datasource_test.dart` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a04bf4f4832c85fda3a38fa0e492