### PR TITLE
Fix build errors in symptom features

### DIFF
--- a/food_diary/lib/core/injection/injection.config.dart
+++ b/food_diary/lib/core/injection/injection.config.dart
@@ -18,14 +18,15 @@ import 'package:food_diary/domain/usecases/add_food_entry.dart' as _i67;
 import 'package:food_diary/domain/usecases/delete_food_entry.dart' as _i723;
 import 'package:food_diary/domain/usecases/get_entries_by_date.dart' as _i758;
 import 'package:food_diary/domain/usecases/update_food_entry.dart' as _i189;
-import 'package:food_diary/data/datasources/symptom_local_datasource.dart' as _i200;
-import 'package:food_diary/domain/repositories/symptom_repository.dart' as _i201;
+import 'package:food_diary/data/datasources/symptom_local_datasource.dart'
+    as _i200;
+import 'package:food_diary/domain/repositories/symptom_repository.dart'
+    as _i201;
 import 'package:food_diary/domain/usecases/add_symptom.dart' as _i202;
 import 'package:food_diary/domain/usecases/update_symptom.dart' as _i203;
 import 'package:food_diary/domain/usecases/delete_symptom.dart' as _i204;
 import 'package:food_diary/domain/usecases/get_symptoms_by_date.dart' as _i205;
 import 'package:food_diary/domain/usecases/get_symptom_frequency.dart' as _i206;
-import 'package:food_diary/data/repositories/symptom_repository_impl.dart' as _i207;
 import 'package:get_it/get_it.dart' as _i174;
 import 'package:injectable/injectable.dart' as _i526;
 
@@ -62,15 +63,9 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i205.GetSymptomsByDate>(
       () => injectionModule.getSymptomsByDate,
     );
-    gh.lazySingleton<_i202.AddSymptom>(
-      () => injectionModule.addSymptom,
-    );
-    gh.lazySingleton<_i203.UpdateSymptom>(
-      () => injectionModule.updateSymptom,
-    );
-    gh.lazySingleton<_i204.DeleteSymptom>(
-      () => injectionModule.deleteSymptom,
-    );
+    gh.lazySingleton<_i202.AddSymptom>(() => injectionModule.addSymptom);
+    gh.lazySingleton<_i203.UpdateSymptom>(() => injectionModule.updateSymptom);
+    gh.lazySingleton<_i204.DeleteSymptom>(() => injectionModule.deleteSymptom);
     gh.lazySingleton<_i206.GetSymptomFrequency>(
       () => injectionModule.getSymptomFrequency,
     );

--- a/food_diary/lib/data/repositories/symptom_repository_impl.dart
+++ b/food_diary/lib/data/repositories/symptom_repository_impl.dart
@@ -38,18 +38,27 @@ class SymptomRepositoryImpl implements SymptomRepository {
   @override
   Future<Symptom?> getSymptomById(String id) async {
     final list = await localDataSource.getSymptomsByDate(DateTime.now());
-    return list.firstWhere((e) => e.id == id, orElse: () => null);
+    for (final symptom in list) {
+      if (symptom.id == id) return symptom;
+    }
+    return null;
   }
 
   @override
-  Future<List<Symptom>> getSymptomsBetweenDates(DateTime start, DateTime end) async {
+  Future<List<Symptom>> getSymptomsBetweenDates(
+    DateTime start,
+    DateTime end,
+  ) async {
     // not implemented: gather by frequency
     final freq = await localDataSource.getSymptomsByDate(start);
     return freq; // placeholder
   }
 
   @override
-  Future<Map<String, int>> getSymptomFrequency(DateTime start, DateTime end) async {
+  Future<Map<String, int>> getSymptomFrequency(
+    DateTime start,
+    DateTime end,
+  ) async {
     return localDataSource.symptomFrequency(start, end);
   }
 }

--- a/food_diary/lib/presentation/pages/symptoms_page.dart
+++ b/food_diary/lib/presentation/pages/symptoms_page.dart
@@ -54,9 +54,7 @@ class _SymptomsPageState extends State<SymptomsPage>
             _buildHeader(),
             _buildDateSelector(),
             _buildSeverityFilter(),
-            Expanded(
-              child: _buildSymptomsList(),
-            ),
+            Expanded(child: _buildSymptomsList()),
           ],
         ),
       ),
@@ -74,16 +72,13 @@ class _SymptomsPageState extends State<SymptomsPage>
               Text(
                 'Symptom Tracker',
                 style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-                      fontWeight: FontWeight.bold,
-                    ),
+                  fontWeight: FontWeight.bold,
+                ),
               ),
               const SizedBox(height: 4),
               Text(
                 'Monitor your reactions',
-                style: TextStyle(
-                  color: Colors.grey.shade600,
-                  fontSize: 14,
-                ),
+                style: TextStyle(color: Colors.grey.shade600, fontSize: 14),
               ),
             ],
           ),
@@ -113,9 +108,7 @@ class _SymptomsPageState extends State<SymptomsPage>
           IconButton(
             icon: const Icon(Icons.chevron_left),
             onPressed: () => _changeDate(-1),
-            style: IconButton.styleFrom(
-              backgroundColor: Colors.grey.shade100,
-            ),
+            style: IconButton.styleFrom(backgroundColor: Colors.grey.shade100),
           ),
           GestureDetector(
             onTap: _selectDate,
@@ -134,9 +127,7 @@ class _SymptomsPageState extends State<SymptomsPage>
           IconButton(
             icon: const Icon(Icons.chevron_right),
             onPressed: () => _changeDate(1),
-            style: IconButton.styleFrom(
-              backgroundColor: Colors.grey.shade100,
-            ),
+            style: IconButton.styleFrom(backgroundColor: Colors.grey.shade100),
           ),
         ],
       ),
@@ -189,10 +180,7 @@ class _SymptomsPageState extends State<SymptomsPage>
       avatar: Container(
         width: 12,
         height: 12,
-        decoration: BoxDecoration(
-          color: color,
-          shape: BoxShape.circle,
-        ),
+        decoration: BoxDecoration(color: color, shape: BoxShape.circle),
       ),
     );
   }
@@ -203,59 +191,32 @@ class _SymptomsPageState extends State<SymptomsPage>
         if (state is SymptomLoading) {
           return const Center(child: CircularProgressIndicator());
         }
-        List<Symptom> list = [];
+
+        List<Symptom> symptoms = [];
         if (state is SymptomLoaded) {
-          list = state.symptoms;
+          symptoms = state.symptoms;
         }
-        if (list.isEmpty) {
+
+        if (symptoms.isEmpty) {
           return Center(
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 Icon(
                   Icons.check_circle_outline,
-              size: 64,
-              color: Colors.grey.shade300,
-            ),
-            const SizedBox(height: 16),
-            Text(
-              'No symptoms recorded today',
-              style: TextStyle(
-                color: Colors.grey.shade600,
-                fontSize: 16,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'That\'s great news!',
-              style: TextStyle(
-                color: Colors.grey.shade500,
-                fontSize: 14,
-              ),
-            ),
-          ],
-        ),
-      );
-    }
-
-    return AnimationLimiter(
-      child: ListView.builder(
-        padding: const EdgeInsets.only(bottom: 100),
-        itemCount: symptoms.length,
-        itemBuilder: (context, index) {
-          return AnimationConfiguration.staggeredList(
-            position: index,
-            duration: const Duration(milliseconds: 375),
-            child: SlideAnimation(
-              verticalOffset: 50.0,
-              child: FadeInAnimation(
-                child: AnimatedSymptomCard(
-                  symptom: symptoms[index],
-                  onEdit: () {},
-                  onDelete: () {},
+                  size: 64,
+                  color: Colors.grey.shade300,
                 ),
-              ),
-            ),
+                const SizedBox(height: 16),
+                Text(
+                  'No symptoms recorded today',
+                  style: TextStyle(color: Colors.grey.shade600, fontSize: 16),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  "That's great news!",
+                  style: TextStyle(color: Colors.grey.shade500, fontSize: 14),
+                ),
               ],
             ),
           );
@@ -264,8 +225,9 @@ class _SymptomsPageState extends State<SymptomsPage>
         return AnimationLimiter(
           child: ListView.builder(
             padding: const EdgeInsets.only(bottom: 100),
-            itemCount: list.length,
+            itemCount: symptoms.length,
             itemBuilder: (context, index) {
+              final symptom = symptoms[index];
               return AnimationConfiguration.staggeredList(
                 position: index,
                 duration: const Duration(milliseconds: 375),
@@ -273,10 +235,10 @@ class _SymptomsPageState extends State<SymptomsPage>
                   verticalOffset: 50.0,
                   child: FadeInAnimation(
                     child: AnimatedSymptomCard(
-                      symptom: list[index],
+                      symptom: symptom,
                       onEdit: () {},
                       onDelete: () {
-                        _symptomBloc.add(DeleteSymptomEvent(list[index].id));
+                        _symptomBloc.add(DeleteSymptomEvent(symptom.id));
                       },
                     ),
                   ),
@@ -305,9 +267,7 @@ class _SymptomsPageState extends State<SymptomsPage>
       builder: (context, child) {
         return Theme(
           data: Theme.of(context).copyWith(
-            colorScheme: ColorScheme.light(
-              primary: AppTheme.primaryColor,
-            ),
+            colorScheme: ColorScheme.light(primary: AppTheme.primaryColor),
           ),
           child: child!,
         );

--- a/food_diary/test/symptom_local_datasource_test.dart
+++ b/food_diary/test/symptom_local_datasource_test.dart
@@ -28,4 +28,4 @@ void main() {
     final result = await dataSource.getSymptomsByDate(DateTime.now());
     expect(result.first.name, 'Test');
   });
-});
+}


### PR DESCRIPTION
## Summary
- fix symptom repository `getSymptomById` return type
- repair `SymptomsPage` symptom list builder logic
- close main function in datasource test
- remove unused import from injection config

## Testing
- `dart analyze` *(fails: Target of URI doesn't exist)*
- `dart test` *(fails to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6841c3f592f8832c82390e0d6079d202