### PR TITLE
Add centralized DatabaseProvider

### DIFF
--- a/food_diary/lib/core/injection/injection_module.dart
+++ b/food_diary/lib/core/injection/injection_module.dart
@@ -1,5 +1,6 @@
 import 'package:injectable/injectable.dart';
 import '../../data/datasources/food_entry_local_datasource.dart';
+import '../../data/datasources/database_provider.dart';
 import '../../data/repositories/food_entry_repository_impl.dart';
 import '../../domain/repositories/food_entry_repository.dart';
 import '../../domain/usecases/add_food_entry.dart';
@@ -18,7 +19,11 @@ import '../../domain/usecases/get_symptom_frequency.dart';
 @module
 abstract class InjectionModule {
   @lazySingleton
-  FoodEntryLocalDataSource get foodEntryLocalDataSource => FoodEntryLocalDataSourceImpl();
+  DatabaseProvider get databaseProvider => DatabaseProvider.instance;
+
+  @lazySingleton
+  FoodEntryLocalDataSource get foodEntryLocalDataSource =>
+      FoodEntryLocalDataSourceImpl(databaseProvider: databaseProvider);
 
   @lazySingleton
   FoodEntryRepository get foodEntryRepository => FoodEntryRepositoryImpl(
@@ -38,7 +43,8 @@ abstract class InjectionModule {
   DeleteFoodEntry get deleteFoodEntry => DeleteFoodEntry(foodEntryRepository);
 
   @lazySingleton
-  SymptomLocalDataSource get symptomLocalDataSource => SymptomLocalDataSourceImpl();
+  SymptomLocalDataSource get symptomLocalDataSource =>
+      SymptomLocalDataSourceImpl(databaseProvider: databaseProvider);
 
   @lazySingleton
   SymptomRepository get symptomRepository => SymptomRepositoryImpl(

--- a/food_diary/lib/data/datasources/database_provider.dart
+++ b/food_diary/lib/data/datasources/database_provider.dart
@@ -1,0 +1,49 @@
+import 'package:path/path.dart';
+import 'package:sqflite/sqflite.dart';
+
+class DatabaseProvider {
+  static final DatabaseProvider instance = DatabaseProvider._internal();
+
+  static const _databaseName = 'food_diary.db';
+  static const _databaseVersion = 2;
+
+  Database? _database;
+
+  DatabaseProvider._internal();
+
+  Future<Database> get database async {
+    if (_database != null) return _database!;
+    final path = join(await getDatabasesPath(), _databaseName);
+    _database = await openDatabase(
+      path,
+      version: _databaseVersion,
+      onCreate: _onCreate,
+    );
+    return _database!;
+  }
+
+  Future<void> _onCreate(Database db, int version) async {
+    await db.execute('''
+      CREATE TABLE food_entries (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        ingredients TEXT NOT NULL,
+        dateTime TEXT NOT NULL,
+        notes TEXT,
+        mealType INTEGER NOT NULL,
+        tags TEXT NOT NULL
+      )
+    ''');
+
+    await db.execute('''
+      CREATE TABLE symptoms(
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        severity INTEGER NOT NULL,
+        occurredAt TEXT NOT NULL,
+        notes TEXT,
+        potentialTriggerIds TEXT NOT NULL
+      )
+    ''');
+  }
+}

--- a/food_diary/test/symptom_local_datasource_test.dart
+++ b/food_diary/test/symptom_local_datasource_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:food_diary/data/datasources/database_provider.dart';
 import 'package:food_diary/data/datasources/symptom_local_datasource.dart';
 import 'package:food_diary/domain/entities/symptom.dart';
 import 'package:food_diary/data/models/symptom_model.dart';
@@ -10,8 +11,11 @@ void main() {
 
   late SymptomLocalDataSource dataSource;
 
-  setUp(() {
-    dataSource = SymptomLocalDataSourceImpl();
+  setUp(() async {
+    await DatabaseProvider.instance.database;
+    dataSource = SymptomLocalDataSourceImpl(
+      databaseProvider: DatabaseProvider.instance,
+    );
   });
 
   test('insert and retrieve symptom', () async {


### PR DESCRIPTION
## Summary
- create `DatabaseProvider` singleton to open the database and create tables
- refactor `FoodEntryLocalDataSourceImpl` and `SymptomLocalDataSourceImpl` to use this provider
- inject the shared provider in `InjectionModule`
- update symptom datasource test to initialize the provider before use

## Testing
- `flutter pub get` *(fails: 403 Forbidden)*
- `flutter test` *(fails: 403 Forbidden)*
- `dart test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841c94f1128832ca47391b775c9e239