### PR TITLE
Add symptom date range retrieval

### DIFF
--- a/food_diary/lib/data/repositories/symptom_repository_impl.dart
+++ b/food_diary/lib/data/repositories/symptom_repository_impl.dart
@@ -49,9 +49,8 @@ class SymptomRepositoryImpl implements SymptomRepository {
     DateTime start,
     DateTime end,
   ) async {
-    // not implemented: gather by frequency
-    final freq = await localDataSource.getSymptomsByDate(start);
-    return freq; // placeholder
+    final symptoms = await localDataSource.getSymptomsBetweenDates(start, end);
+    return symptoms;
   }
 
   @override

--- a/food_diary/test/symptom_local_datasource_test.dart
+++ b/food_diary/test/symptom_local_datasource_test.dart
@@ -28,4 +28,54 @@ void main() {
     final result = await dataSource.getSymptomsByDate(DateTime.now());
     expect(result.first.name, 'Test');
   });
+
+  test('retrieve symptoms between dates', () async {
+    final base = DateTime(2024, 1, 1, 12);
+    final symptoms = [
+      SymptomModel(
+        id: '1',
+        name: 'Prev',
+        severity: SeverityLevel.mild,
+        occurredAt: base.subtract(const Duration(days: 1)),
+        potentialTriggerIds: const [],
+      ),
+      SymptomModel(
+        id: '2',
+        name: 'Base',
+        severity: SeverityLevel.moderate,
+        occurredAt: base,
+        potentialTriggerIds: const [],
+      ),
+      SymptomModel(
+        id: '3',
+        name: 'Next',
+        severity: SeverityLevel.severe,
+        occurredAt: base.add(const Duration(days: 1)),
+        potentialTriggerIds: const [],
+      ),
+      SymptomModel(
+        id: '4',
+        name: 'Out',
+        severity: SeverityLevel.mild,
+        occurredAt: base.add(const Duration(days: 2)),
+        potentialTriggerIds: const [],
+      ),
+    ];
+
+    for (final s in symptoms) {
+      await dataSource.insertSymptom(s);
+    }
+
+    final result = await dataSource.getSymptomsBetweenDates(
+      base.subtract(const Duration(days: 1)),
+      base.add(const Duration(days: 1)),
+    );
+
+    expect(result.length, 3);
+    final ids = result.map((e) => e.id);
+    expect(ids, contains('1'));
+    expect(ids, contains('2'));
+    expect(ids, contains('3'));
+    expect(ids, isNot(contains('4')));
+  });
 }


### PR DESCRIPTION
## Summary
- add `getSymptomsBetweenDates` interface and implementation
- connect repository to new method
- test retrieving symptoms between a date range

## Testing
- `flutter test` *(fails: Proxy failed to establish tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_6841c95a29c0832c9861fbe88d8a20cd