### PR TITLE
Add getAllSymptoms to SymptomLocalDataSource

### DIFF
--- a/food_diary/lib/data/datasources/symptom_local_datasource.dart
+++ b/food_diary/lib/data/datasources/symptom_local_datasource.dart
@@ -4,6 +4,7 @@ import 'package:path/path.dart';
 import '../models/symptom_model.dart';
 
 abstract class SymptomLocalDataSource {
+  Future<List<SymptomModel>> getAllSymptoms();
   Future<List<SymptomModel>> getSymptomsByDate(DateTime date);
   Future<void> insertSymptom(SymptomModel symptom);
   Future<void> updateSymptom(SymptomModel symptom);
@@ -56,6 +57,13 @@ class SymptomLocalDataSourceImpl implements SymptomLocalDataSource {
       await db.execute('DROP TABLE IF EXISTS $_tableName');
       await _onCreate(db, newVersion);
     }
+  }
+
+  @override
+  Future<List<SymptomModel>> getAllSymptoms() async {
+    final db = await database;
+    final maps = await db.query(_tableName);
+    return maps.map((e) => SymptomModel.fromJson(_deserialize(e))).toList();
   }
 
   @override

--- a/food_diary/lib/data/repositories/symptom_repository_impl.dart
+++ b/food_diary/lib/data/repositories/symptom_repository_impl.dart
@@ -32,7 +32,7 @@ class SymptomRepositoryImpl implements SymptomRepository {
 
   @override
   Future<List<Symptom>> getAllSymptoms() async {
-    return localDataSource.getSymptomsByDate(DateTime.now());
+    return localDataSource.getAllSymptoms();
   }
 
   @override

--- a/food_diary/test/symptom_local_datasource_test.dart
+++ b/food_diary/test/symptom_local_datasource_test.dart
@@ -28,4 +28,28 @@ void main() {
     final result = await dataSource.getSymptomsByDate(DateTime.now());
     expect(result.first.name, 'Test');
   });
+
+  test('get all symptoms returns every stored symptom', () async {
+    final symptom1 = SymptomModel(
+      id: '1',
+      name: 'One',
+      severity: SeverityLevel.mild,
+      occurredAt: DateTime.now(),
+      potentialTriggerIds: const [],
+    );
+    final symptom2 = SymptomModel(
+      id: '2',
+      name: 'Two',
+      severity: SeverityLevel.moderate,
+      occurredAt: DateTime.now().add(const Duration(days: 1)),
+      potentialTriggerIds: const [],
+    );
+
+    await dataSource.insertSymptom(symptom1);
+    await dataSource.insertSymptom(symptom2);
+
+    final all = await dataSource.getAllSymptoms();
+    expect(all.length, 2);
+    expect(all.map((e) => e.id).toSet(), {'1', '2'});
+  });
 }


### PR DESCRIPTION
## Summary
- support retrieving every stored symptom
- use the new data source method in the repository
- verify retrieval in unit tests

## Testing
- `flutter test test/symptom_local_datasource_test.dart -r expanded` *(fails: Proxy failed to establish tunnel 403)*

------
https://chatgpt.com/codex/tasks/task_e_6841c95d072c832c995581e7fff2b32f