### PR TITLE
Improve chip colors on Add meal screen

### DIFF
--- a/food_diary/lib/presentation/pages/add_food_entry_page.dart
+++ b/food_diary/lib/presentation/pages/add_food_entry_page.dart
@@ -246,7 +246,7 @@ class _AddFoodEntryPageState extends State<AddFoodEntryPage> {
                     _ingredients.remove(ingredient);
                   });
                 },
-                backgroundColor: Colors.grey.shade100,
+                backgroundColor: Colors.grey.shade200,
               );
             }).toList(),
           ),
@@ -283,10 +283,10 @@ class _AddFoodEntryPageState extends State<AddFoodEntryPage> {
                   }
                 });
               },
-              backgroundColor: Colors.white,
+              backgroundColor: Colors.grey.shade100,
               selectedColor: tag.toLowerCase().contains('contains')
-                  ? AppTheme.warningColor.withOpacity(0.2)
-                  : AppTheme.primaryColor.withOpacity(0.2),
+                  ? AppTheme.warningColor.withOpacity(0.3)
+                  : AppTheme.primaryColor.withOpacity(0.3),
               checkmarkColor: tag.toLowerCase().contains('contains')
                   ? AppTheme.warningColor
                   : AppTheme.primaryColor,
@@ -295,7 +295,7 @@ class _AddFoodEntryPageState extends State<AddFoodEntryPage> {
                     ? (tag.toLowerCase().contains('contains')
                         ? AppTheme.warningColor
                         : AppTheme.primaryColor)
-                    : Colors.grey.shade300,
+                    : Colors.grey.shade400,
               ),
             );
           }).toList(),


### PR DESCRIPTION
## Summary
- tweak chip backgrounds for ingredients and tags
- make selected tag chips brighter and tweak borders

## Testing
- `flutter test` *(fails: Proxy failed to establish tunnel)*
- `flutter analyze` *(fails: Proxy failed to establish tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_6841d52d563c832cb968d24f64ed1ec9