### PR TITLE
Add onboarding screens

### DIFF
--- a/food_diary/lib/main.dart
+++ b/food_diary/lib/main.dart
@@ -4,16 +4,21 @@ import 'core/injection/injection.dart';
 import 'presentation/blocs/food_entry/food_entry_bloc.dart';
 import 'presentation/blocs/symptom/symptom_bloc.dart';
 import 'presentation/pages/main_page.dart';
+import 'presentation/pages/onboarding_page.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'presentation/theme/app_theme.dart';
 
-void main() {
+Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   configureDependencies();
-  runApp(const MyApp());
+  final prefs = await SharedPreferences.getInstance();
+  final completed = prefs.getBool('onboarding_completed') ?? false;
+  runApp(MyApp(onboardingCompleted: completed));
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  final bool onboardingCompleted;
+  const MyApp({super.key, required this.onboardingCompleted});
 
   @override
   Widget build(BuildContext context) {
@@ -24,23 +29,25 @@ class MyApp extends StatelessWidget {
       home: MultiBlocProvider(
         providers: [
           BlocProvider(
-            create: (context) => FoodEntryBloc(
-              getEntriesByDate: getIt(),
-              addFoodEntry: getIt(),
-              updateFoodEntry: getIt(),
-              deleteFoodEntry: getIt(),
-            ),
+            create:
+                (context) => FoodEntryBloc(
+                  getEntriesByDate: getIt(),
+                  addFoodEntry: getIt(),
+                  updateFoodEntry: getIt(),
+                  deleteFoodEntry: getIt(),
+                ),
           ),
           BlocProvider(
-            create: (context) => SymptomBloc(
-              getSymptomsByDate: getIt(),
-              addSymptom: getIt(),
-              updateSymptom: getIt(),
-              deleteSymptom: getIt(),
-            ),
+            create:
+                (context) => SymptomBloc(
+                  getSymptomsByDate: getIt(),
+                  addSymptom: getIt(),
+                  updateSymptom: getIt(),
+                  deleteSymptom: getIt(),
+                ),
           ),
         ],
-        child: const MainPage(),
+        child: onboardingCompleted ? const MainPage() : const OnboardingPage(),
       ),
     );
   }

--- a/food_diary/lib/presentation/pages/onboarding_page.dart
+++ b/food_diary/lib/presentation/pages/onboarding_page.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../theme/app_theme.dart';
+import 'main_page.dart';
+
+class OnboardingPage extends StatefulWidget {
+  const OnboardingPage({super.key});
+
+  @override
+  State<OnboardingPage> createState() => _OnboardingPageState();
+}
+
+class _OnboardingPageState extends State<OnboardingPage> {
+  final PageController _controller = PageController();
+  int _currentIndex = 0;
+
+  final List<_OnboardData> _pages = const [
+    _OnboardData(Icons.restaurant_menu, 'Track your meals'),
+    _OnboardData(Icons.warning_amber_rounded, 'Log your symptoms'),
+    _OnboardData(Icons.analytics, 'Analyze correlations'),
+  ];
+
+  Future<void> _completeOnboarding() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('onboarding_completed', true);
+    if (mounted) {
+      Navigator.of(
+        context,
+      ).pushReplacement(MaterialPageRoute(builder: (_) => const MainPage()));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: PageView.builder(
+                controller: _controller,
+                onPageChanged: (i) => setState(() => _currentIndex = i),
+                itemCount: _pages.length,
+                itemBuilder: (context, index) {
+                  final page = _pages[index];
+                  return Padding(
+                    padding: const EdgeInsets.all(32),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(
+                          page.icon,
+                          size: 120,
+                          color: AppTheme.primaryColor,
+                        ),
+                        const SizedBox(height: 32),
+                        Text(
+                          page.text,
+                          textAlign: TextAlign.center,
+                          style: Theme.of(context).textTheme.headlineSmall,
+                        ),
+                      ],
+                    ),
+                  );
+                },
+              ),
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: List.generate(_pages.length, (index) {
+                return AnimatedContainer(
+                  duration: const Duration(milliseconds: 200),
+                  margin: const EdgeInsets.all(4),
+                  width: 8,
+                  height: 8,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color:
+                        _currentIndex == index
+                            ? AppTheme.primaryColor
+                            : Colors.grey,
+                  ),
+                );
+              }),
+            ),
+            const SizedBox(height: 24),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+              child: SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed:
+                      _currentIndex == _pages.length - 1
+                          ? _completeOnboarding
+                          : () => _controller.nextPage(
+                            duration: const Duration(milliseconds: 300),
+                            curve: Curves.easeInOut,
+                          ),
+                  child: Text(
+                    _currentIndex == _pages.length - 1 ? 'Get Started' : 'Next',
+                  ),
+                ),
+              ),
+            ),
+            TextButton(
+              onPressed: _completeOnboarding,
+              child: const Text('Skip'),
+            ),
+            const SizedBox(height: 16),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _OnboardData {
+  final IconData icon;
+  final String text;
+  const _OnboardData(this.icon, this.text);
+}

--- a/food_diary/pubspec.yaml
+++ b/food_diary/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   injectable: ^2.3.2
   uuid: ^4.3.3
   path: ^1.9.0
+  shared_preferences: ^2.2.2
   animations: ^2.0.11
   flutter_staggered_animations: ^1.1.1
   shimmer: ^3.0.0


### PR DESCRIPTION
## Summary
- add an onboarding page with multiple slides
- show onboarding only the first time the app launches
- include shared_preferences dependency

## Testing
- `dart format -o write food_diary/lib/main.dart food_diary/lib/presentation/pages/onboarding_page.dart`
- `flutter pub get` *(fails: Proxy failed to establish tunnel)*
- `flutter test` *(fails: Proxy failed to establish tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_6842ed75ea2c832c8cbeb8fe15116393